### PR TITLE
fix: make builtin types be modified by "keyword"

### DIFF
--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -160,7 +160,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
 
     -- types
     -- ["@type"] = hl.syntax["Type"], -- types
-    ["@type.builtin"] = { fg = c.builtin, gui = "bold" }, --builtin types
+    ["@type.builtin"] = { fg = c.builtin, gui = config.style.keywords }, --builtin types
     -- ["@type.definition"] = hl.syntax["Typedef"], -- typedefs
     -- ["@type.qualifier"]
 


### PR DESCRIPTION
Having every style set to "none" did not made the following normal.

![prev](https://github.com/user-attachments/assets/a934fef7-ba1f-4355-b2db-5ef0a833dbfd)

After the changes made, it works as spected.

![after](https://github.com/user-attachments/assets/4567ee5e-6f6f-45e9-8afb-4c710224a854)
