### PR TITLE
builtin constants can know be configured with 'builtin_constants'

### DIFF
--- a/lua/vague/config.lua
+++ b/lua/vague/config.lua
@@ -11,6 +11,7 @@ local M = {}
 ---@field keyword_return? CodeStyle
 ---@field strings? CodeStyle
 ---@field variables? CodeStyle
+---@field builtin_constants? CodeStyle
 
 ---@class VagueConfig.colors
 ---@field bg? string
@@ -55,6 +56,7 @@ local DEFAULT_SETTINGS = {
     keyword_return = "none",
     strings = "italic",
     variables = "none",
+    builtin_constants = "none",
   },
   -- Override colors
   colors = {

--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -137,7 +137,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
     -- ["@variable.field"] = { fg = c.builtin }, -- fields
 
     -- ["@constant"] = { link = "Constant" }, -- constants
-    ["@constant.builtin"] = { fg = c.builtin, gui = config.style.keywords }, -- constants that are defined by the language, like 'nil' in lua
+    ["@constant.builtin"] = { fg = c.builtin, gui = config.style.builtin_constants }, -- constants that are defined by the language, like 'nil' in lua
     -- ["@constant.macro"] = { link = "Macro" }, -- constants that are defined by macros like 'NULL' in c
 
     -- ["@label"] = { link = "Label" }, -- labels

--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -137,7 +137,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
     -- ["@variable.field"] = { fg = c.builtin }, -- fields
 
     -- ["@constant"] = { link = "Constant" }, -- constants
-    ["@constant.builtin"] = { fg = c.builtin, gui = "bold" }, -- constants that are defined by the language, like 'nil' in lua
+    ["@constant.builtin"] = { fg = c.builtin, gui = config.style.keywords }, -- constants that are defined by the language, like 'nil' in lua
     -- ["@constant.macro"] = { link = "Macro" }, -- constants that are defined by macros like 'NULL' in c
 
     -- ["@label"] = { link = "Label" }, -- labels


### PR DESCRIPTION
In Go, builtin constants like `iota` couldn't be configured with the "keywords" style.

Know they can.