### PR TITLE
add bg.line to telescope.selection

### DIFF
--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -324,7 +324,7 @@ hl.plugins.telescope = {
   TelescopeBorder = { fg = c.floatBorder },
   TelescopeMatching = { fg = c.delta, gui = "bold" },
   TelescopePromptPrefix = { fg = c.constant },
-  TelescopeSelection = { fg = c.constant, bg = c.bg },
+  TelescopeSelection = { fg = c.constant, bg = c.line },
   TelescopeSelectionCaret = { fg = c.type },
   TelescopeResultsNormal = { fg = c.fg },
 }


### PR DESCRIPTION
nearly impossible to see what line in a telescope picker you have selected without this.