### PR TITLE
Support rainbow delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ require("vague").setup({
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [Snacks](https://github.com/folke/snacks.nvim)
 - [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ require("vague").setup({
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
 
 ## Contributing
 

--- a/lua/vague/groups/init.lua
+++ b/lua/vague/groups/init.lua
@@ -14,4 +14,5 @@ return {
   dashboard = require("vague.groups.dashboard").get_colors(curr_internal_conf),
   snacks_picker = require("vague.groups.snacks-picker").get_colors(curr_internal_conf),
   snacks_input = require("vague.groups.snacks-input").get_colors(curr_internal_conf),
+  rainbow_delimiters = require("vague.groups.rainbow-delimiters").get_colors(curr_internal_conf),
 }

--- a/lua/vague/groups/rainbow-delimiters.lua
+++ b/lua/vague/groups/rainbow-delimiters.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+---@param conf VagueColorscheme.InternalConfig
+---@return table
+M.get_colors = function(conf)
+  local c = conf.colors
+
+  -- stylua: ignore
+  local hl = {
+    RainbowDelimiterRed    = { fg = c.error },
+    RainbowDelimiterOrange = { fg = c.func },
+    RainbowDelimiterYellow = { fg = c.warning },
+    RainbowDelimiterGreen  = { fg = c.plus },
+    RainbowDelimiterBlue   = { fg = c.hint },
+    RainbowDelimiterViolet = { fg = c.parameter },
+    RainbowDelimiterCyan   = { fg = c.keyword },
+  }
+
+  return hl
+end
+return M


### PR DESCRIPTION
Hi,

I'd like to add support for the [rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim) plugin.
It only requires a view highlights and I hope I picked the correct colors.

How it looks on my machine:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/7ed7cf64-56b8-4322-8f24-c6b3ecffd821" />
