### PR TITLE
feat: support mini.diff and mini.trailspace plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ require("vague").setup({
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - [Snacks](https://github.com/folke/snacks.nvim)
 - [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
+- [Mini](https://github.com/echasnovski/mini.nvim)
 
 ## Contributing
 

--- a/lua/vague/groups/init.lua
+++ b/lua/vague/groups/init.lua
@@ -7,6 +7,7 @@ return {
   lsp_plugin = require("vague.groups.lsp-plugin").get_colors(curr_internal_conf),
   gitsigns = require("vague.groups.gitsigns").get_colors(curr_internal_conf),
   neotest = require("vague.groups.neotest").get_colors(curr_internal_conf),
+  mini = require("vague.groups.mini").get_colors(curr_internal_conf),
   neotree = require("vague.groups.neotree").get_colors(curr_internal_conf),
   syntax = require("vague.groups.syntax").get_colors(curr_internal_conf),
   telescope = require("vague.groups.telescope").get_colors(curr_internal_conf),

--- a/lua/vague/groups/mini.lua
+++ b/lua/vague/groups/mini.lua
@@ -1,0 +1,24 @@
+local M = {}
+
+---@param conf VagueColorscheme.InternalConfig
+---@return table
+M.get_colors = function(conf)
+  local utilities = require("vague.utilities")
+  local c = conf.colors
+
+  -- stylua: ignore
+  local hl = {
+    MiniDiffOverAdd = { fg = c.plus, bg = utilities.blend(c.plus, c.bg, 0.2) },
+    MiniDiffOverChange = { fg = c.delta, bg = utilities.blend(c.delta, c.bg, 0.2)},
+    MiniDiffOverContext = { bg = c.line },
+    MiniDiffOverDelete = { fg = c.error, bg = utilities.blend(c.error, c.bg, 0.2) },
+    MiniDiffSignAdd     = { fg = c.plus },
+    MiniDiffSignChange  = { fg = c.delta },
+    MiniDiffSignDelete  = { fg = c.error },
+
+    MiniTrailspace = { bg = c.error },
+  }
+
+  return hl
+end
+return M

--- a/lua/vague/utilities.lua
+++ b/lua/vague/utilities.lua
@@ -1,0 +1,40 @@
+local utilities = {}
+
+---@param color string
+local function color_to_rgb(color)
+  local function byte(value, offset) return bit.band(bit.rshift(value, offset), 0xFF) end
+
+  local new_color = vim.api.nvim_get_color_by_name(color)
+  if new_color == -1 then new_color = vim.opt.background:get() == "dark" and 000 or 255255255 end
+
+  return { byte(new_color, 16), byte(new_color, 8), byte(new_color, 0) }
+end
+
+local blend_cache = {}
+
+--- Blends two colors based on alpha transparency.
+--- Adapted from: https://github.com/rose-pine/neovim/blob/main/lua/rose-pine/utilities.lua
+--- Original license: MIT
+---@param color string Color to blend
+---@param base_color string Base color to blend on
+---@param alpha number Between 0 (background) and 1 (foreground)
+---@return string # A hex color string like "#RRGGBB"
+function utilities.blend(color, base_color, alpha)
+  local cache_key = color .. base_color .. alpha
+  if blend_cache[cache_key] then return blend_cache[cache_key] end
+
+  local fg_rgb = color_to_rgb(color)
+  local bg_rgb = color_to_rgb(base_color)
+
+  local function blend_channel(i)
+    local ret = (alpha * fg_rgb[i] + ((1 - alpha) * bg_rgb[i]))
+    return math.floor(math.min(math.max(0, ret), 255) + 0.5)
+  end
+
+  local result = string.format("#%02X%02X%02X", blend_channel(1), blend_channel(2), blend_channel(3))
+
+  blend_cache[cache_key] = result
+  return result
+end
+
+return utilities


### PR DESCRIPTION
Fixes some [mini.nvim](https://github.com/echasnovski/mini.nvim) modules. Adds bg color for [mini.trailspace](https://github.com/echasnovski/mini.trailspace) and support for [mini.diff](https://github.com/echasnovski/mini.diff). Here is demo screenshot:
![2025-05-07-131741_sway-screenshot](https://github.com/user-attachments/assets/b62058e6-13fe-4331-898f-117c0bb76ac4)
