### PR TITLE
Add Preset Zellij config

### DIFF
--- a/extras/zellij/vague.kdl.rtf
+++ b/extras/zellij/vague.kdl.rtf
@@ -1,138 +1,137 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2709
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+# Vague for Zellij
+# -------------------
+# Theme Author: vague2k <ilovedrawing056@gmail.com>
+# Ported by:	madsfranzen <madsfranzen@live.dk>
+# License:  	MIT License
+# Upstream: 	https://github.com/vague2k/vague.nvim/blob/main/extras/ghostty/vague
 
-\f0\fs24 \cf0 themes \{\
-    vague \{\
-        text_unselected \{\
-            base 205 205 205\
-            background 20 20 21\
-            emphasis_0 248 197 107  \
-            emphasis_1 110 148 178     \
-            emphasis_2 187 157 189    \
-            emphasis_3 174 174 209   \
-        \}\
-        text_selected \{\
-            base 205 205 205\
-            background 37 37 48\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        ribbon_selected \{\
-            base 20 20 21\
-            background 110 148 178\
-            emphasis_0 20 20 21\
-            emphasis_1 248 197 107\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        ribbon_unselected \{\
-            base 20 20 21\
-            background 96 96 121\
-            emphasis_0 20 20 21\
-            emphasis_1 205 205 205\
-            emphasis_2 174 174 209\
-            emphasis_3 187 157 189\
-        \}\
-        table_title \{\
-            base 110 148 178\
-            background 0\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        table_cell_selected \{\
-            base 205 205 205\
-            background 37 37 48\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        table_cell_unselected \{\
-            base 205 205 205\
-            background 20 20 21\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        list_selected \{\
-            base 205 205 205\
-            background 37 37 48\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        list_unselected \{\
-            base 205 205 205\
-            background 20 20 21\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        frame_unselected \{\
-            base 0 45 65\
-            background 0\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 0\
-        \}\
-        frame_selected \{\
-            base 0 70 120\
-            background 0\
-            emphasis_0 248 197 107\
-            emphasis_1 110 148 178\
-            emphasis_2 187 157 189\
-            emphasis_3 0\
-        \}\
-        frame_highlight \{\
-            base 248 197 107\
-            background 0\
-            emphasis_0 187 157 189\
-            emphasis_1 248 197 107\
-            emphasis_2 248 197 107\
-            emphasis_3 248 197 107\
-        \}\
-        exit_code_success \{\
-            base 110 148 178\
-            background 0\
-            emphasis_0 127 165 99    \
-            emphasis_1 0 0 0\
-            emphasis_2 187 157 189\
-            emphasis_3 174 174 209\
-        \}\
-        exit_code_error \{\
-            base 0 0 0\
-            background 0\
-            emphasis_0 216 100 126  \
-            emphasis_1 0\
-            emphasis_2 0\
-            emphasis_3 0\
-        \}\
-        multiplayer_user_colors \{\
-            player_1 187 157 189\
-            player_2 174 174 209\
-            player_3 0\
-            player_4 248 197 107\
-            player_5 110 148 178\
-            player_6 0\
-            player_7 0 0 0\
-            player_8 0\
-            player_9 0\
-            player_10 0\
-        \}\
-    \}\
-\}\
-\
-\
-theme "vague"}
+themes {
+    vague {
+        text_unselected {
+            base 205 205 205
+            background 20 20 21
+            emphasis_0 248 197 107  
+            emphasis_1 110 148 178     
+            emphasis_2 187 157 189    
+            emphasis_3 174 174 209   
+        }
+        text_selected {
+            base 205 205 205
+            background 37 37 48
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        ribbon_selected {
+            base 20 20 21
+            background 110 148 178
+            emphasis_0 20 20 21
+            emphasis_1 248 197 107
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        ribbon_unselected {
+            base 20 20 21
+            background 96 96 121
+            emphasis_0 20 20 21
+            emphasis_1 205 205 205
+            emphasis_2 174 174 209
+            emphasis_3 187 157 189
+        }
+        table_title {
+            base 110 148 178
+            background 0
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        table_cell_selected {
+            base 205 205 205
+            background 37 37 48
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        table_cell_unselected {
+            base 205 205 205
+            background 20 20 21
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        list_selected {
+            base 205 205 205
+            background 37 37 48
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        list_unselected {
+            base 205 205 205
+            background 20 20 21
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        frame_unselected {
+            base 0 45 65
+            background 0
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 0
+        }
+        frame_selected {
+            base 0 70 120
+            background 0
+            emphasis_0 248 197 107
+            emphasis_1 110 148 178
+            emphasis_2 187 157 189
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 248 197 107
+            background 0
+            emphasis_0 187 157 189
+            emphasis_1 248 197 107
+            emphasis_2 248 197 107
+            emphasis_3 248 197 107
+        }
+        exit_code_success {
+            base 110 148 178
+            background 0
+            emphasis_0 127 165 99    
+            emphasis_1 0 0 0
+            emphasis_2 187 157 189
+            emphasis_3 174 174 209
+        }
+        exit_code_error {
+            base 0 0 0
+            background 0
+            emphasis_0 216 100 126  
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 187 157 189
+            player_2 174 174 209
+            player_3 0
+            player_4 248 197 107
+            player_5 110 148 178
+            player_6 0
+            player_7 0 0 0
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
+}
+
+theme "vague"

--- a/extras/zellij/vague.kdl.rtf
+++ b/extras/zellij/vague.kdl.rtf
@@ -1,0 +1,138 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2709
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 themes \{\
+    vague \{\
+        text_unselected \{\
+            base 205 205 205\
+            background 20 20 21\
+            emphasis_0 248 197 107  \
+            emphasis_1 110 148 178     \
+            emphasis_2 187 157 189    \
+            emphasis_3 174 174 209   \
+        \}\
+        text_selected \{\
+            base 205 205 205\
+            background 37 37 48\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        ribbon_selected \{\
+            base 20 20 21\
+            background 110 148 178\
+            emphasis_0 20 20 21\
+            emphasis_1 248 197 107\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        ribbon_unselected \{\
+            base 20 20 21\
+            background 96 96 121\
+            emphasis_0 20 20 21\
+            emphasis_1 205 205 205\
+            emphasis_2 174 174 209\
+            emphasis_3 187 157 189\
+        \}\
+        table_title \{\
+            base 110 148 178\
+            background 0\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        table_cell_selected \{\
+            base 205 205 205\
+            background 37 37 48\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        table_cell_unselected \{\
+            base 205 205 205\
+            background 20 20 21\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        list_selected \{\
+            base 205 205 205\
+            background 37 37 48\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        list_unselected \{\
+            base 205 205 205\
+            background 20 20 21\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        frame_unselected \{\
+            base 0 45 65\
+            background 0\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 0\
+        \}\
+        frame_selected \{\
+            base 0 70 120\
+            background 0\
+            emphasis_0 248 197 107\
+            emphasis_1 110 148 178\
+            emphasis_2 187 157 189\
+            emphasis_3 0\
+        \}\
+        frame_highlight \{\
+            base 248 197 107\
+            background 0\
+            emphasis_0 187 157 189\
+            emphasis_1 248 197 107\
+            emphasis_2 248 197 107\
+            emphasis_3 248 197 107\
+        \}\
+        exit_code_success \{\
+            base 110 148 178\
+            background 0\
+            emphasis_0 127 165 99    \
+            emphasis_1 0 0 0\
+            emphasis_2 187 157 189\
+            emphasis_3 174 174 209\
+        \}\
+        exit_code_error \{\
+            base 0 0 0\
+            background 0\
+            emphasis_0 216 100 126  \
+            emphasis_1 0\
+            emphasis_2 0\
+            emphasis_3 0\
+        \}\
+        multiplayer_user_colors \{\
+            player_1 187 157 189\
+            player_2 174 174 209\
+            player_3 0\
+            player_4 248 197 107\
+            player_5 110 148 178\
+            player_6 0\
+            player_7 0 0 0\
+            player_8 0\
+            player_9 0\
+            player_10 0\
+        \}\
+    \}\
+\}\
+\
+\
+theme "vague"}


### PR DESCRIPTION
### This PR introduces a port of the [Vague](https://github.com/vague2k/vague.nvim) theme to Zellij. It’s an opinionated take, inspired by the original, with a few subjective choices.

I use Zellij as my daily driver and felt the absence of a Vague-style theme in its ecosystem. This port is meant to fill that gap and provide a starting point for others who enjoy the aesthetic.

**This is not a 1:1 match with the original theme – some colors and contrasts have been adjusted.**

**Totally open to feedback and changes – consider this a proposal more than a final version.**

- [x] Basic theme ported
- [x] Tested in Zellij v0.42.2
- [ ] Open to suggestions before merge