### PR TITLE
Config option to disable bold and italics globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 ```lua
 require("vague").setup({
   transparent = false, -- don't set background
+  -- disable bold/italic globally in `style`
+  bold = true,
+  italic = true,
   style = {
     -- "none" is the same thing as default. But "italic" and "bold" are also valid options
     boolean = "bold",

--- a/lua/vague/config/internal.lua
+++ b/lua/vague/config/internal.lua
@@ -5,6 +5,10 @@ local DEFAULT_SETTINGS = {
 
   ---@type boolean
   transparent = false,
+  ---@type boolean
+  bold = true,
+  ---@type boolean
+  italic = true,
   ---@class VagueColorscheme.InternalConfig.style
   style = {
     ---@type string

--- a/lua/vague/config/meta.lua
+++ b/lua/vague/config/meta.lua
@@ -91,6 +91,8 @@
 
 ---@class VagueColorscheme.Config
 ---@field transparent? boolean
+---@field bold? boolean
+---@field italic? boolean
 ---@field style? VagueColorscheme.style
 ---@field colors? VagueColorscheme.colors
 ---@field plugins? VagueColorscheme.plugins

--- a/lua/vague/groups/syntax.lua
+++ b/lua/vague/groups/syntax.lua
@@ -5,21 +5,6 @@ local M = {}
 ---@return table
 M.get_colors = function(conf)
   local c = conf.colors
-  -- override bold/italic if global setting is set to false
-  conf.style = vim.iter(conf.style):fold(
-    {},
-    ---@param v CodeStyle
-    function(acc, k, v)
-      if v == "bold" and not conf.bold then
-        v = "none"
-      elseif v == "italic" and not conf.italic then
-        v = "none"
-      end
-      acc[k] = v
-      return acc
-    end
-  )
-
     -- stylua: ignore
   local hl = {
     Boolean         = { fg = c.number, gui = conf.style.boolean },             -- boolean constants

--- a/lua/vague/groups/syntax.lua
+++ b/lua/vague/groups/syntax.lua
@@ -5,6 +5,20 @@ local M = {}
 ---@return table
 M.get_colors = function(conf)
   local c = conf.colors
+  -- override bold/italic if global setting is set to false
+  conf.style = vim.iter(conf.style):fold(
+    {},
+    ---@param v CodeStyle
+    function(acc, k, v)
+      if v == "bold" and not conf.bold then
+        v = "none"
+      elseif v == "italic" and not conf.italic then
+        v = "none"
+      end
+      acc[k] = v
+      return acc
+    end
+  )
 
     -- stylua: ignore
   local hl = {

--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -5,6 +5,11 @@ local M = {}
 ---@param highlights table <string, table>
 local function set_vim_highlights(highlights)
   for name, setting in pairs(highlights) do
+    if setting.gui == "bold" and not curr_internal_conf.bold then
+      setting.gui = "none"
+    elseif setting.gui == "italic" and not curr_internal_conf.italic then
+      setting.gui = "none"
+    end
     vim.api.nvim_command(
       string.format(
         "highlight %s guifg=%s guibg=%s guisp=%s gui=%s",


### PR DESCRIPTION
hi,
this is a simple change to be able to disable bold and italics globally instead of looking up which style is changed and setting it manually to `"none"`.  i think it can come in useful for those that want their font to remain regular.