### PR TITLE
Add Xresources port

### DIFF
--- a/extras/xresources/vague
+++ b/extras/xresources/vague
@@ -1,0 +1,34 @@
+*.foreground: #cdcdcd
+*.background: #141415
+
+! black
+*.color0:       #252530
+*.color8:       #606079
+
+! red
+*.color1:       #d8647e
+*.color9:       #e08398
+
+! green
+*.color2:       #7fa563
+*.color10:      #99b782
+
+! yellow
+*.color3:       #f3be7c
+*.color11:      #f5cb96
+
+! blue
+*.color4:       #6e94b2
+*.color12:      #8ba9c1
+
+! magenta
+*.color5:       #bb9dbd
+*.color13:      #c9b1ca
+
+! cyan
+*.color6:       #aeaed1
+*.color14:      #bebeda
+
+! white
+*.color7:       #cdcdcd
+*.color15:      #d7d7d7

--- a/extras/xresources/vague
+++ b/extras/xresources/vague
@@ -1,5 +1,6 @@
-*.foreground: #cdcdcd
-*.background: #141415
+*.foreground: 	#cdcdcd
+*.background: 	#141415
+*.cursorColor: 	#cdcdcd
 
 ! black
 *.color0:       #252530


### PR DESCRIPTION
Ported Vague to Xresources, which is used by X11 software like st, dwm, nsxiv, and more.