### PR TITLE
feat: add diagnostic_ok highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ require("vague").setup({
       diagnostic_error = "bold",
       diagnostic_hint = "none",
       diagnostic_info = "italic",
+      diagnostic_ok = "none",
       diagnostic_warn = "bold",
     },
     neotest = {

--- a/lua/vague/config/internal.lua
+++ b/lua/vague/config/internal.lua
@@ -81,6 +81,8 @@ local DEFAULT_SETTINGS = {
       ---@type string
       diagnostic_info = "italic",
       ---@type string
+      diagnostic_ok = "none",
+      ---@type string
       diagnostic_warn = "bold",
     },
     ---@class VagueColorscheme.InternalConfig.plugins.neotest

--- a/lua/vague/config/meta.lua
+++ b/lua/vague/config/meta.lua
@@ -57,6 +57,7 @@
 ---@field diagnostic_error? CodeStyle -- lsp diagnostic error text
 ---@field diagnostic_hint? CodeStyle -- lsp diagnostic hint text
 ---@field diagnostic_info? CodeStyle -- lsp diagnostic info text
+---@field diagnostic_ok? CodeStyle -- lsp diagnostic ok text
 ---@field diagnostic_warn? CodeStyle -- lsp diagnostic warn text
 
 ---@class VagueColorscheme.plugins

--- a/lua/vague/groups/lsp-plugin.lua
+++ b/lua/vague/groups/lsp-plugin.lua
@@ -10,13 +10,16 @@ M.get_colors = function(conf)
     DiagnosticError               = { fg = c.error, gui = conf.plugins.lsp.diagnostic_error },   -- diagnostic error
     DiagnosticHint                = { fg = c.hint, gui = conf.plugins.lsp.diagnostic_hint},      -- diagnostic hint
     DiagnosticInfo                = { fg = c.constant, gui = conf.plugins.lsp.diagnostic_info }, -- diagnostic info
+    DiagnosticOk                  = { fg = c.plus, gui = conf.plugins.lsp.diagnostic_ok },       -- diagnostic ok
     DiagnosticUnderlineError      = { gui = "undercurl", sp = c.error },                         -- undercurl for errors
     DiagnosticUnderlineHint       = { gui = "undercurl", sp = c.hint },                          -- undercurl for hints
     DiagnosticUnderlineInfo       = { gui = "undercurl", sp = c.hint },                          -- undercurl for info
+    DiagnosticUnderlineOk         = { gui = "undercurl", sp = c.plus },                          -- undercurl for ok
     DiagnosticUnderlineWarn       = { gui = "undercurl", sp = c.delta },                         -- undercurl for warnings
     DiagnosticVirtualTextError    = { fg = c.error, gui = conf.plugins.lsp.diagnostic_error },   -- virtual text for errors
     DiagnosticVirtualTextHint     = { fg = c.hint, gui = conf.plugins.lsp.diagnostic_hint},      -- virtual text for hints
     DiagnosticVirtualTextInfo     = { fg = c.delta, gui = conf.plugins.lsp.diagnostic_info },    -- virtual text for info
+    DiagnosticVirtualTextOk       = { fg = c.plus, gui = conf.plugins.lsp.diagnostic_ok },       -- virtual text for ok
     DiagnosticVirtualTextWarn     = { fg = c.warning, gui = conf.plugins.lsp.diagnostic_warn },  -- virtual text for warnings
     DiagnosticWarn                = { fg = c.warning, gui = conf.plugins.lsp.diagnostic_warn},   -- diagnostic warning
     LspCodeLens                   = { fg = c.comment, gui = conf.style.comments },               -- code lens text


### PR DESCRIPTION
This commit adds the missing DiagnosticOk and similar highlight groups per this discussion: https://github.com/vague2k/vague.nvim/pull/38#issuecomment-2917695769

One other thing I noticed while looking at the diagnostics in that they seem to be inconsistent. It becomes immediately apparent when you sort them by diagnostic level. For example, Error, Hint, and Ok are consistent, but Info and Warn are not. I'm not sure if that is by design. 

```
    DiagnosticError               = { fg = c.error, gui = conf.plugins.lsp.diagnostic_error },   -- diagnostic error
    DiagnosticUnderlineError      = { gui = "undercurl", sp = c.error },                         -- undercurl for errors
    DiagnosticVirtualTextError    = { fg = c.error, gui = conf.plugins.lsp.diagnostic_error },   -- virtual text for errors

    DiagnosticHint                = { fg = c.hint, gui = conf.plugins.lsp.diagnostic_hint},      -- diagnostic hint
    DiagnosticUnderlineHint       = { gui = "undercurl", sp = c.hint },                          -- undercurl for hints
    DiagnosticVirtualTextHint     = { fg = c.hint, gui = conf.plugins.lsp.diagnostic_hint},      -- virtual text for hints

    DiagnosticInfo                = { fg = c.constant, gui = conf.plugins.lsp.diagnostic_info }, -- diagnostic info
    DiagnosticUnderlineInfo       = { gui = "undercurl", sp = c.hint },                          -- undercurl for info
    DiagnosticVirtualTextInfo     = { fg = c.delta, gui = conf.plugins.lsp.diagnostic_info },    -- virtual text for info

    DiagnosticOk                  = { fg = c.plus, gui = conf.plugins.lsp.diagnostic_ok },       -- diagnostic ok
    DiagnosticUnderlineOk         = { gui = "undercurl", sp = c.plus },                          -- undercurl for ok
    DiagnosticVirtualTextOk       = { fg = c.plus, gui = conf.plugins.lsp.diagnostic_ok },       -- virtual text for ok

    DiagnosticUnderlineWarn       = { gui = "undercurl", sp = c.delta },                         -- undercurl for warnings
    DiagnosticWarn                = { fg = c.warning, gui = conf.plugins.lsp.diagnostic_warn},   -- diagnostic warning
    DiagnosticVirtualTextWarn     = { fg = c.warning, gui = conf.plugins.lsp.diagnostic_warn },  -- virtual text for warnings
```