### PR TITLE
feat(extras): Zellij theme

### DIFF
--- a/extras/zellij/vague.kdl
+++ b/extras/zellij/vague.kdl
@@ -1,0 +1,129 @@
+themes {
+	vague {
+		text_unselected {
+			base 205 205 205
+			background 20 20 21
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		text_selected {
+			base 205 205 205
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		ribbon_unselected {
+			base 37 37 48
+			background 205 205 205
+			emphasis_0 37 37 48
+			emphasis_1 205 205 205
+			emphasis_2 243 190 124
+			emphasis_3 187 157 189
+		}
+		ribbon_selected {
+			base 37 37 48
+			background 110 148 178
+			emphasis_0 37 37 48
+			emphasis_1 243 190 124
+			emphasis_2 187 157 189
+			emphasis_3 243 190 124
+		}
+		table_title {
+			base 127 165 99
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		table_cell_unselected {
+			base 205 205 205
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		table_cell_selected {
+			base 205 205 205
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		list_unselected {
+			base 205 205 205
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		list_selected {
+			base 205 205 205
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 110 148 178
+			emphasis_3 187 157 189
+		}
+		frame_selected {
+			base 174 174 209
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 174 174 209
+			emphasis_2 187 157 189
+			emphasis_3 37 37 48
+		}
+		frame_unselected {
+			base 96 96 121
+			background 96 96 121
+			emphasis_0 96 96 121
+			emphasis_1 96 96 121
+			emphasis_2 96 96 121
+			emphasis_3 96 96 121
+		}
+		frame_highlight {
+			base 243 190 124
+			background 37 37 48
+			emphasis_0 187 157 189
+			emphasis_1 243 190 124
+			emphasis_2 243 190 124
+			emphasis_3 243 190 124
+		}
+		exit_code_success {
+			base 127 165 99
+			background 37 37 48
+			emphasis_0 174 174 209
+			emphasis_1 37 37 48
+			emphasis_2 187 157 189
+			emphasis_3 243 190 124
+		}
+		exit_code_error {
+			base 216 100 126
+			background 37 37 48
+			emphasis_0 243 190 124
+			emphasis_1 37 37 48
+			emphasis_2 37 37 48
+			emphasis_3 37 37 48
+		}
+		multiplayer_user_colors {
+			player_1 187 157 189
+			player_2 243 190 124
+			player_3 37 37 48
+			player_4 174 174 209
+			player_5 216 100 126
+			player_6 37 37 48
+			player_7 127 165 99
+			player_8 37 37 48
+			player_9 37 37 48
+			player_10 37 37 48
+		}
+	}
+}
+


### PR DESCRIPTION
Supersedes #32

Adds a Zellij theme based on the original `vague.nvim` colors - all taken from the base8 palette used in terminal themes.

<details>
<summary>Screenshots</summary>
With default layout:
<img width="2560" height="1421" alt="1752884993_screenshot" src="https://github.com/user-attachments/assets/82adc56f-e5ff-4b65-aceb-d8d3be98cc7a" />

With my personal tmux-like one:
<img width="2560" height="1419" alt="1752886255_screenshot" src="https://github.com/user-attachments/assets/37853292-5ab2-4cf2-ad6a-ee66ab55b5c2" />
</details>