### PR TITLE
feat: support nvim-treesitter/nvim-treesitter-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ require("vague").setup({
 - [Neotest](https://github.com/nvim-neotest/neotest)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [Treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context)
 - [Snacks](https://github.com/folke/snacks.nvim)
 - [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
 - [Mini](https://github.com/echasnovski/mini.nvim)

--- a/lua/vague/groups/init.lua
+++ b/lua/vague/groups/init.lua
@@ -13,6 +13,7 @@ return {
   syntax = require("vague.groups.syntax").get_colors(curr_internal_conf),
   telescope = require("vague.groups.telescope").get_colors(curr_internal_conf),
   treesitter = require("vague.groups.treesitter").get_colors(curr_internal_conf),
+  treesitter_context = require("vague.groups.treesitter-context").get_colors(curr_internal_conf),
   dashboard = require("vague.groups.dashboard").get_colors(curr_internal_conf),
   snacks_picker = require("vague.groups.snacks-picker").get_colors(curr_internal_conf),
   snacks_input = require("vague.groups.snacks-input").get_colors(curr_internal_conf),

--- a/lua/vague/groups/treesitter-context.lua
+++ b/lua/vague/groups/treesitter-context.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+---@param conf VagueColorscheme.InternalConfig
+---@return table
+M.get_colors = function(conf)
+  local c = conf.colors
+
+    --stylua: ignore
+  local hl = {
+    TreesitterContext           = { bg = c.line },
+    TreesitterContextLineNumber = { fg = c.comment, bg = c.line },
+  }
+
+  return hl
+end
+return M

--- a/lua/vague/groups/treesitter.lua
+++ b/lua/vague/groups/treesitter.lua
@@ -2,7 +2,6 @@ local syntax_group = require("vague.groups.syntax")
 local diff_group = require("vague.groups.diff")
 local M = {}
 
----comment
 ---@param conf VagueColorscheme.InternalConfig
 ---@return table
 M.get_colors = function(conf)


### PR DESCRIPTION
Support for [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context).

This adds the missing highlight groups, improving visual distinction between context and buffer content.

Before:
<img width="1272" height="729" alt="1753094697_screenshot" src="https://github.com/user-attachments/assets/b5a591aa-9c16-47b1-a0c0-bc7a99880949" />

After:
<img width="1272" height="729" alt="1753094671_screenshot" src="https://github.com/user-attachments/assets/71eddeca-0c1f-4576-baa1-d0c305473742" />
