### PR TITLE
fix(extras): foot cursor.color -> colors.cursor

### DIFF
--- a/extras/foot/vague
+++ b/extras/foot/vague
@@ -5,12 +5,10 @@
 # License:  	MIT License
 # Upstream: 	https://github.com/vague2k/vague.nvim/blob/main/extras/foot/vague
 
-[cursor]
-color=141415 cdcdcd
-
 [colors]
 background=141415
 foreground=cdcdcd
+cursor=141415 cdcdcd
 
 regular0=252530
 regular1=d8647e


### PR DESCRIPTION
Adapts foot config to [deprecation of `cursor.color`](https://codeberg.org/dnkl/foot/commit/624c383a1f45a4fbd5ebf687613c509e6c22d909) to suppress warnings on startup.