### PR TITLE
feat: add missing builtin groups: Added, Changed, Removed

### DIFF
--- a/lua/vague/groups/diff.lua
+++ b/lua/vague/groups/diff.lua
@@ -8,12 +8,15 @@ M.get_colors = function(conf)
 
   -- stylua: ignore
   local hl = {
-    DiffAdd          = { fg = c.plus, bg = utilities.blend(c.plus, c.bg, 0.2) },
-    DiffChange       = { fg = c.delta, bg = utilities.blend(c.delta, c.bg, 0.2) },
-    DiffDelete       = { fg = c.error, bg = utilities.blend(c.error, c.bg, 0.2) },
-    DiffText         = { fg = c.fg },
-    DiffFile         = { fg = c.keyword },
-    DiffIndexLine    = { fg = c.comment },
+    Added         = { fg = c.plus },
+    Changed       = { fg = c.delta },
+    Removed       = { fg = c.error },
+    DiffAdd       = { fg = c.plus, bg = utilities.blend(c.plus, c.bg, 0.2) },
+    DiffChange    = { fg = c.delta, bg = utilities.blend(c.delta, c.bg, 0.2) },
+    DiffDelete    = { fg = c.error, bg = utilities.blend(c.error, c.bg, 0.2) },
+    DiffText      = { fg = c.fg },
+    DiffFile      = { fg = c.keyword },
+    DiffIndexLine = { fg = c.comment },
   }
 
   return hl

--- a/lua/vague/groups/mini.lua
+++ b/lua/vague/groups/mini.lua
@@ -1,17 +1,12 @@
-local diff_group = require("vague.groups.diff")
 local M = {}
 
 ---@param conf VagueColorscheme.InternalConfig
 ---@return table
 M.get_colors = function(conf)
   local c = conf.colors
-  local diff = diff_group.get_colors(conf)
 
   -- stylua: ignore
   local hl = {
-    MiniDiffOverAdd     = diff["DiffAdd"],
-    MiniDiffOverChange  = diff["DiffChange"],
-    MiniDiffOverDelete  = diff["DiffDelete"],
     MiniDiffOverContext = { bg = c.line },
     MiniDiffSignAdd     = { fg = c.plus },
     MiniDiffSignChange  = { fg = c.delta },


### PR DESCRIPTION
This adds some missing builtin highlight groups: Added, Changed, Removed.

Also removes explicit linking of MiniDiff* highlight groups that are already linked by default, avoiding redundancy.