### PR TITLE
feat: improve netrw highlighting

### DIFF
--- a/lua/vague/groups/init.lua
+++ b/lua/vague/groups/init.lua
@@ -4,6 +4,7 @@ return {
   diff = require("vague.groups.diff").get_colors(curr_internal_conf),
   cmp = require("vague.groups.cmp").get_colors(curr_internal_conf),
   blink = require("vague.groups.blink").get_colors(curr_internal_conf),
+  netrw = require("vague.groups.netrw").get_colors(curr_internal_conf),
   lsp_native = require("vague.groups.lsp-native").get_colors(curr_internal_conf),
   lsp_plugin = require("vague.groups.lsp-plugin").get_colors(curr_internal_conf),
   gitsigns = require("vague.groups.gitsigns").get_colors(curr_internal_conf),

--- a/lua/vague/groups/netrw.lua
+++ b/lua/vague/groups/netrw.lua
@@ -1,0 +1,18 @@
+local common_group = require("vague.groups.common")
+local M = {}
+
+---@param conf VagueColorscheme.InternalConfig
+---@return table
+M.get_colors = function(conf)
+  local c = conf.colors
+  local common = common_group.get_colors(conf)
+
+  -- stylua: ignore
+  local hl = {
+    netrwTreeBar  = { fg = c.comment },
+    netrwClassify = common["Directory"],
+  }
+
+  return hl
+end
+return M


### PR DESCRIPTION
Adds more reasonable highlighting for vim builtin file browser: Netrw.

Before/After:


<img width="287" height="743" alt="1753855261_screenshot" src="https://github.com/user-attachments/assets/63d31a70-d03b-476b-be4c-7af74c617773" />

<img width="307" height="741" alt="1753859041_screenshot" src="https://github.com/user-attachments/assets/cd572642-416e-4544-811e-c07f76758cad" />
