### PR TITLE
perf: avoid redundant :highlight calls for treesitter and LSP groups

### DIFF
--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -24,13 +24,6 @@ local function set_vim_highlights(highlights)
 end
 
 M.set_highlights = function()
-  if groups.treesitter and vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
-    set_vim_highlights(groups.treesitter)
-  end
-  if groups.lsp_native and vim.api.nvim_call_function("has", { "nvim-0.9" }) == 1 then
-    set_vim_highlights(groups.lsp_native)
-  end
-
   local highlights = {}
   for _, group in pairs(groups) do
     for hl, settings in pairs(group) do


### PR DESCRIPTION
This removes extra calls to `set_vim_highlights` for treesitter and LSP
highlight groups. These calls were unnecessary because all groups are
later collected into `local highlights` and passed to `set_vim_highlights` anyway.

To confirm this I did a simple "benchmark" with counter:
```lua
local c = 0
---@param highlights table <string, table>
local function set_vim_highlights(highlights)
  for name, setting in pairs(highlights) do
  c = c + 1
  print(name, c)
```

Before/After:
<img width="706" height="233" alt="1754203233_screenshot" src="https://github.com/user-attachments/assets/b8d0ca6b-9261-44d4-a2be-791b5518a8ee" />
<img width="738" height="219" alt="1754203163_screenshot" src="https://github.com/user-attachments/assets/f4a3f3cd-a232-40ce-be8c-375cb08a1d0f" />


While I understand the idea behind optionally applying hl-groups, I don't think it's worth it because:
a) unused highlight groups have no performance cost,
b) they will exist anyway due to plugin-specific groups.