### PR TITLE
chore: add .luarc.json

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+	"runtime.version": "LuaJIT",
+	"workspace": {
+		"library": [
+			"$VIMRUNTIME"
+		],
+		"checkThirdParty": false
+	}
+}


### PR DESCRIPTION
Recommended way of bringing `vim` global in scope without lazydev.nvim.