### PR TITLE
fix(extras): use dynamic cursor color in terminal themes

### DIFF
--- a/extras/foot/vague
+++ b/extras/foot/vague
@@ -8,7 +8,6 @@
 [colors]
 background=141415
 foreground=cdcdcd
-cursor=141415 cdcdcd
 
 regular0=252530
 regular1=d8647e

--- a/extras/ghostty/vague
+++ b/extras/ghostty/vague
@@ -24,6 +24,5 @@ palette = 15=#d7d7d7
 
 background = #141415
 foreground = #cdcdcd
-cursor-color = #cdcdcd
 selection-background = #252530
 selection-foreground = #cdcdcd

--- a/extras/kitty/vague.conf
+++ b/extras/kitty/vague.conf
@@ -10,8 +10,7 @@ background               #141415
 selection_foreground     #cdcdcd
 selection_background     #252530
 
-cursor                   #cdcdcd
-cursor_text_color        #cdcdcd
+cursor                   none
 
 url_color                #bb9dbd
 

--- a/extras/windows_terminal/vauge.json
+++ b/extras/windows_terminal/vauge.json
@@ -20,6 +20,5 @@
 
   "background": "#141414",
   "foreground": "#cdcdcd",
-  "selectionBackground": "#252530",
-  "cursorColor": "#cdcdcd"
+  "selectionBackground": "#252530"
 }


### PR DESCRIPTION
Fixes #66

Explicitly setting the cursor color overrides the default behavior of inverting the cursor background with the text foreground in terminal emulators that support it. Users who prefer a custom color can still override it, but dynamic inversion is a better default.

The Alacritty port already behaves this way, `st` appears not to support this behavior - so those were left unchanged.