### PR TITLE
fix(extras): add some missing colors for Alacritty

### DIFF
--- a/extras/alacritty/vague.toml
+++ b/extras/alacritty/vague.toml
@@ -28,3 +28,19 @@ blue = '#8ba9c1'
 magenta = '#c9b1ca'
 cyan = '#bebeda'
 white = '#d7d7d7'
+
+[colors.hints.start]
+foreground = "CellBackground"
+background = "CellForeground"
+
+[colors.hints.end]
+foreground = "CellBackground"
+background = "CellForeground"
+
+[colors.search.matches]
+foreground = "CellBackground"
+background = "CellForeground"
+
+[colors.search.focused_match]
+foreground = "CellBackground"
+background = '#f3be7c'


### PR DESCRIPTION
This fix overrides the default red color and applies a few visual improvements.

## Screenshots Before/After:

Search matches:
<img width="350" alt="1756037194_screenshot" src="https://github.com/user-attachments/assets/5b9fb069-4104-4158-baa4-f27f0ae4f7b3" />
<img width="350" alt="1756037134_screenshot" src="https://github.com/user-attachments/assets/33f65de7-6356-43fd-9d74-1ea85dc88b72" />

Hyperlink selection:
<img width="400" alt="1756037188_screenshot" src="https://github.com/user-attachments/assets/f57fc26d-0fc6-4db9-8bee-f3555fdef62e" />
<img width="400" alt="1756037163_screenshot" src="https://github.com/user-attachments/assets/4e8f58f6-f25f-4547-9298-f3afae8a13b0" />

 