### PR TITLE
feat: support fzf-lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ require("vague").setup({
 - [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
 - [Mini](https://github.com/echasnovski/mini.nvim)
 - [Vim-better-whitespace](https://github.com/ntpeters/vim-better-whitespace)
+- [Fzf-lua](https://github.com/ibhagwan/fzf-lua)
 
 ## Extras
 

--- a/lua/vague/groups/fzf-lua.lua
+++ b/lua/vague/groups/fzf-lua.lua
@@ -1,0 +1,28 @@
+local common_group = require("vague.groups.common")
+local M = {}
+
+---@param conf VagueColorscheme.InternalConfig
+---@return table
+M.get_colors = function(conf)
+  local c = conf.colors
+  local common = common_group.get_colors(conf)
+
+  -- stylua: ignore
+  local hl = {
+    FzfLuaHeaderBind = { fg = c.constant },
+    FzfLuaHeaderText = { fg = c.parameter },
+    FzfLuaBorder     = common["FloatBorder"],
+    FzfLuaPathLineNr = { fg = c.string },
+    FzfLuaPathColNr  = { fg = c.parameter },
+    FzfLuaLivePrompt = { fg = c.constant },
+    FzfLuaLiveSym    = { fg = c.string },
+    FzfLuaBufNr      = { fg = c.string },
+    FzfLuaBufFlagCur = { fg = c.keyword },
+    FzfLuaBufFlagAlt = { fg = c.keyword },
+    FzfLuaTabTitle   = { fg = c.type },
+    FzfLuaTabMarker  = { fg = c.constant },
+  }
+
+  return hl
+end
+return M

--- a/lua/vague/groups/init.lua
+++ b/lua/vague/groups/init.lua
@@ -20,4 +20,5 @@ return {
   snacks_indent = require("vague.groups.snacks-indent").get_colors(curr_internal_conf),
   rainbow_delimiters = require("vague.groups.rainbow-delimiters").get_colors(curr_internal_conf),
   vim_better_whitespace = require("vague.groups.vim-better-whitespace").get_colors(curr_internal_conf),
+  fzf_lua = require("vague.groups.fzf-lua").get_colors(curr_internal_conf),
 }


### PR DESCRIPTION
Improves highlighting for the [fzf-lua](https://github.com/ibhagwan/fzf-lua) plugin.

Some screenshots before/after:

<img width="1009" height="283" alt="1756677935_screenshot" src="https://github.com/user-attachments/assets/5d9f4895-b9f9-4b80-9709-23a69d681349" />
<img width="1009" height="278" alt="1756677975_screenshot" src="https://github.com/user-attachments/assets/a64009c5-27d5-4d79-bd2d-2c02a25d381e" />

<img alt="1756677724_screenshot" src="https://github.com/user-attachments/assets/118c8fa2-1e1c-407b-ac88-675768cdfa78" />
<img alt="1756677694_screenshot" src="https://github.com/user-attachments/assets/95558df7-2acd-46d5-9460-b1363ba734fb" />
