### PR TITLE
feat: support mini.statusline plugin

### DIFF
--- a/lua/vague/groups/mini.lua
+++ b/lua/vague/groups/mini.lua
@@ -13,6 +13,17 @@ M.get_colors = function(conf)
     MiniDiffSignDelete  = { fg = c.error },
 
     MiniTrailspace      = { bg = c.error },
+
+    MiniStatuslineModeNormal  = { fg = c.bg, bg = c.operator, gui = "bold" },
+    MiniStatuslineModeInsert  = { fg = c.bg, bg = c.delta, gui = "bold" },
+    MiniStatuslineModeVisual  = { fg = c.bg, bg = c.builtin, gui = "bold" },
+    MiniStatuslineModeReplace = { fg = c.bg, bg = c.string, gui = "bold" },
+    MiniStatuslineModeCommand = { fg = c.bg, bg = c.string, gui = "bold" },
+    MiniStatuslineModeOther   = { fg = c.bg, bg = c.string, gui = "bold" },
+    MiniStatuslineDevinfo     = { fg = c.fg, bg = c.inactiveBg },
+    MiniStatuslineFilename    = { fg = c.comment, bg = c.bg },
+    MiniStatuslineFileinfo    = { fg = c.fg, bg = c.inactiveBg },
+    MiniStatuslineInactive    = { fg = c.comment, bg = c.bg },
   }
 
   return hl


### PR DESCRIPTION
This PR adds support for mini.statusline, using lualine as reference.

**Preview**:
<img width="1872" height="986" alt="image" src="https://github.com/user-attachments/assets/fc1109d9-cfd0-44a7-a7a4-d0ab223f2ad8" />
