### PR TITLE
fix(groups): don't override foreground color for selection

### DIFF
--- a/lua/vague/groups/common.lua
+++ b/lua/vague/groups/common.lua
@@ -62,7 +62,7 @@ M.get_colors = function(conf)
     Terminal         = { fg = c.fg, bg = conf.transparent and "none" or c.bg },
     ToolbarButton    = { fg = c.bg, bg = c.visual },
     ToolbarLine      = { fg = c.fg },
-    Visual           = { fg = c.fg, bg = c.visual },
+    Visual           = { bg = c.visual },
     VisualNOS        = { fg = "none", bg = c.comment, gui = "underline" },
     WarningMsg       = { fg = c.warning, gui = "bold" },
     Whitespace       = { fg = c.comment },


### PR DESCRIPTION
## Before:
<img width="971" height="343" alt="1758842186_screenshot" src="https://github.com/user-attachments/assets/f2abab80-ed9c-4fbf-b057-f758fb6dcde1" />


## After:
<img width="971" height="340" alt="1758842117_screenshot" src="https://github.com/user-attachments/assets/390af6f8-4c28-41cc-803a-e8340d6920b1" />