### PR TITLE
feat(groups): use floatBorder color for `PmenuBorder`

### DIFF
--- a/lua/vague/groups/common.lua
+++ b/lua/vague/groups/common.lua
@@ -43,6 +43,7 @@ M.get_colors = function(conf)
     PmenuSel         = { fg = c.constant, bg = c.line },
     PmenuSbar        = { bg = c.bg },
     PmenuThumb       = { bg = c.comment },
+    PmenuBorder      = { fg = c.floatBorder },
     Question         = { fg = c.constant },
     QuickFixLine     = { fg = c.func, gui = "underline" },
     Search           = { fg = c.fg, bg = c.search or c.visual },


### PR DESCRIPTION
Makes builtin completion popup borders match floating windows and blink.cmp

## Before/After
<img width="372" height="264" alt="1760274360_screenshot" src="https://github.com/user-attachments/assets/32a100db-fd0d-4c7b-a4ef-d00b3d45c343" />
<img width="384" height="264" alt="1760274340_screenshot" src="https://github.com/user-attachments/assets/8de1671c-c8f2-4854-a00d-78b88f78073a" />
