### PR TITLE
fix: reduce brightness of `Whitespace` hl-group

### DIFF
--- a/lua/vague/groups/common.lua
+++ b/lua/vague/groups/common.lua
@@ -61,7 +61,7 @@ M.get_colors = function(conf)
     Visual           = { bg = c.visual },
     VisualNOS        = { bg = c.comment, gui = "underline" },
     WarningMsg       = { fg = c.warning, gui = "bold" },
-    Whitespace       = { fg = c.comment },
+    Whitespace       = { fg = c.line },
     WildMenu         = { fg = c.bg, bg = c.func },
     WinSeparator     = { fg = c.floatBorder },
     WinBar           = { fg = c.fg, bg = c.inactiveBg },


### PR DESCRIPTION
`Whitespace` uses the `comment` color, which makes it appear too bright and visually distracting. This change updates it to use the `line` color instead, providing subtler contrast.

### Before/After

<img alt="before" src="https://github.com/user-attachments/assets/06e5e9c0-3983-4252-a75c-06f6cd03f702" />
<img alt="after" src="https://github.com/user-attachments/assets/b38a554d-1364-491c-a498-55092f5e59b5" />
