### PR TITLE
fix: improve DiffText highlight for inline changes

### DIFF
--- a/lua/vague/groups/diff.lua
+++ b/lua/vague/groups/diff.lua
@@ -14,7 +14,7 @@ M.get_colors = function(conf)
     DiffAdd       = { bg = utilities.blend(c.plus, c.bg, 0.2) },
     DiffChange    = { bg = utilities.blend(c.delta, c.bg, 0.2) },
     DiffDelete    = { bg = utilities.blend(c.error, c.bg, 0.2) },
-    DiffText      = { fg = c.fg },
+    DiffText      = { bg = utilities.blend(c.delta, c.bg, 0.4) },
     DiffFile      = { fg = c.keyword },
     DiffIndexLine = { fg = c.comment },
   }


### PR DESCRIPTION
Previously, DiffText used for highlighting changes within a changed line had no bg and a white fg.

### Before/After
<img width="2178" height="617" alt="1762173299_screenshot" src="https://github.com/user-attachments/assets/8062f9e9-62f0-4f26-9acf-f3d3d8689e5c" />
<img width="2172" height="614" alt="1762173234_screenshot" src="https://github.com/user-attachments/assets/50f9bc22-f52e-4e70-9578-af2f8327960e" />
