### PR TITLE
fix: use background instead of foreground for `Error` group

### DIFF
--- a/lua/vague/groups/mini.lua
+++ b/lua/vague/groups/mini.lua
@@ -12,8 +12,6 @@ M.get_colors = function(conf)
     MiniDiffSignChange  = { fg = c.delta },
     MiniDiffSignDelete  = { fg = c.error },
 
-    MiniTrailspace      = { bg = c.error },
-
     MiniStatuslineModeNormal  = { fg = c.bg, bg = c.operator, gui = "bold" },
     MiniStatuslineModeInsert  = { fg = c.bg, bg = c.delta, gui = "bold" },
     MiniStatuslineModeVisual  = { fg = c.bg, bg = c.builtin, gui = "bold" },

--- a/lua/vague/groups/syntax.lua
+++ b/lua/vague/groups/syntax.lua
@@ -14,7 +14,7 @@ M.get_colors = function(conf)
     Constant        = { fg = c.constant },                                     -- (preferred) any constant
     Define          = { fg = c.comment },                                      -- preprocessor '#define'
     Delimiter       = { fg = c.fg },                                           -- delimiter characters
-    Error           = { fg = c.error, gui = conf.style.error },                -- (preferred) any erroneous construct
+    Error           = { bg = c.error, gui = conf.style.error },                -- (preferred) any erroneous construct
     Exception       = { fg = c.keyword, gui = conf.style.keywords_exception }, -- 'try', 'catch', 'throw'
     Float           = { fg = c.number, gui = conf.style.float },               -- float constants
     Function        = { fg = c.func, gui = conf.style.functions },             -- functions


### PR DESCRIPTION
I noticed that all builtin colorschemes use bg instead of fg for this group, and some plugins like mini.trailspace may rely on that. The only other usage of this group that I found is for syntax errors, and in my opinion, with bg it is more noticeable than with fg.

<img width="695" height="84" alt="1765988446_screenshot" src="https://github.com/user-attachments/assets/63c772cb-eb01-4a68-bebd-e37032dbc71c" />
<img width="703" height="83" alt="1765988442_screenshot" src="https://github.com/user-attachments/assets/b0975f03-1f8e-48fe-9777-4a80ff09a601" />

It's not that important, but since the default colorschemes use bg, I think it's safer to do the same.