### PR TITLE
refactor: switch to vim.api.nvim_set_hl()

### DIFF
--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -2,10 +2,10 @@ local curr_internal_conf = require("vague.config.internal").current
 local groups = require("vague.groups")
 local M = {}
 
----@param highlights table<string, table>
+---@param highlights table<string, table<string, string|boolean>>
 local function set_vim_highlights(highlights)
   for name, setting in pairs(highlights) do
-    local style_string = setting.gui or setting.fmt or ""
+    local style_string = setting.gui or setting.fmt or "" --[[@as string]]
     -- Clear not supported in nvim_set_hl() options
     setting.gui = nil
     setting.fmt = nil


### PR DESCRIPTION
Use the native lua function vim.api.nvim_set_hl() instead of sticking with the :highlight command.

With this change we're still using the old gui settings in order to keep compatibility till we move to the new api.

---
I saw #58 and thought that I could try to use the native function while keeping compatibility so I did it.

Might have a go at migrating everything, but I won't guarantee anything, so I thought that I should at least put this change out.

How should I go about migrating?
@skewb1k, should I make a new branch which superseeds #58 or would I be able to get access and push to that branch?

This is my second pr ever so please bear with me if I say something stupid.