### PR TITLE
fix: respect transparency setting for Pmenu background

### DIFF
--- a/lua/vague/groups/common.lua
+++ b/lua/vague/groups/common.lua
@@ -33,7 +33,7 @@ M.get_colors = function(conf)
     Normal             = { fg = c.fg, bg = not conf.transparent and c.bg or nil },
     NormalFloat        = { fg = c.fg, bg = not conf.transparent and c.inactiveBg or nil },
     ModeMsg            = { fg = c.string },
-    Pmenu              = { fg = c.fg, bg = c.line },
+    Pmenu              = { fg = c.fg, bg = not conf.transparent and c.line or nil },
     PmenuThumb         = { bg = c.comment },
     Question           = { fg = c.constant },
     QuickFixLine       = { bg = c.inactiveBg },


### PR DESCRIPTION
## Problem

When `transparent = true` is set, the `Pmenu` highlight still had an opaque background (`bg = c.line`), causing popup menus to appear with a solid background while other UI elements were transparent

### Before fix images:

<img width="500"  alt="CleanShot 2026-04-20 at 16 58 23@2x" src="https://github.com/user-attachments/assets/53548359-2659-4fff-8be3-65e7cda87623" /> <br>
<img width="500" alt="CleanShot 2026-04-20 at 16 58 42@2x" src="https://github.com/user-attachments/assets/91ddd701-6066-40b1-836f-d15c443ad681" />

### After fix images:

<img width="500" alt="CleanShot 2026-04-20 at 16 59 20@2x" src="https://github.com/user-attachments/assets/ecca8fdf-6a0f-4bdc-9008-089e1f6921e4" /> <br>
<img width="500" alt="CleanShot 2026-04-20 at 16 59 27@2x" src="https://github.com/user-attachments/assets/eab032dd-9a14-412d-a0d0-c5c779b0284a" />
